### PR TITLE
Added pagination for BigQueryTransferList

### DIFF
--- a/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
+++ b/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
@@ -220,40 +220,17 @@ createDataExportIfNeeded:
   steps:
   - init:
       assign:
-        - combinedResults: []
         - transferConfigId: null
   - checkIfTransferConfigExists:
       try:
         steps:
-          - getAllConfigs:
+          - CheckInAllConfigs:
               call: paginateConfigs
               args:
                 parent: ${"projects/" + projectId}
-                combinedResults: ${combinedResults}
+                transferConfigId: ${transferConfigId}
                 pageToken: null
-              result: combinedResults
-          - findConfigId:
-              for:
-                value: transferConfig
-                in: ${combinedResults}
-                steps:
-                  - checkCondition:
-                      switch:
-                        - condition: ${transferConfig.displayName == "RecommenderAPIExport"}
-                          steps:
-                            - export_configId:
-                                assign:
-                                  - transferConfigId: ${transferConfig.name}
-                                # returning as there is no need to continue looping.
-                                next: break
-                  - checkIfTransferConfigWasFound:
-                      switch:
-                        - condition: ${transferConfigId == null}
-                          steps:
-                            - raiseMissingError:
-                                raise: "RecommenderAPIExport was not found in transfer configs"
-                  - finalExists:
-                      return: ${transferConfigId}
+              result: transferConfigId
       except:
         as: e
         steps:
@@ -278,7 +255,7 @@ createDataExportIfNeeded:
 
 # Recursively called step for handling pagination
 paginateConfigs:
-    params: [parent, combinedResults, pageToken]
+    params: [parent, transferConfigId, pageToken]
     steps:
       - listConfigsPage:
           call: googleapis.bigquerydatatransfer.v1.projects.transferConfigs.list
@@ -297,16 +274,24 @@ paginateConfigs:
               - setNextPageTokenNull:
                   assign:
                     - nextPageToken: null
-      - concatResults:
+      - CheckResults:
           steps:
             - looping:
                 for:
                   value: transferConfig
                   in: ${pageResults.transferConfigs}
                   steps:
-                    - combine:
-                        assign:
-                          - combinedResults: ${list.concat(combinedResults, transferConfig)}
+                    - checkCondition:
+                      switch:
+                        - condition: ${transferConfig.displayName == "RecommenderAPIExport"}
+                          steps:
+                            - export_configId:
+                                assign:
+                                  - transferConfigId: ${transferConfig.name}
+                                # returning as there is no need to continue looping.
+                                next: break
+                    - finalExists:
+                        return: ${transferConfigId}
       - checkNextPage:
           switch:
             - condition: ${nextPageToken != null}
@@ -315,13 +300,17 @@ paginateConfigs:
                     call: paginateConfigs
                     args:
                       parent: ${parent}
-                      combinedResults: ${combinedResults}
+                      transferConfigId: ${transferConfigId}
                       pageToken: ${nextPageToken}
-                    result: combinedResults
+                    result: transferConfigId
+            - condition: ${transferConfigId == null}
+              steps:
+                - raiseMissingError:
+                    raise: "RecommenderAPIExport was not found in transfer configs"
             - condition: True
               steps:
                 - finalReturn:
-                    return: ${combinedResults}
+                    return: ${transferConfigId}
 
 
 runExportsInParallel:

--- a/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
+++ b/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
@@ -371,4 +371,3 @@ runExportsInParallel:
                     #    parent: ${transferId}
                     #    body:
                     #      requested_run_time: ${time.format(sys.now())}
-                    

--- a/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
+++ b/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
@@ -304,7 +304,7 @@ paginateConfigs:
                   value: transferConfig
                   in: ${pageResults.transferConfigs}
                   steps:
-                    - combine: 
+                    - combine:
                         assign:
                           - combinedResults: ${list.concat(combinedResults, transferConfig)}
       - checkNextPage:
@@ -371,3 +371,4 @@ runExportsInParallel:
                     #    parent: ${transferId}
                     #    body:
                     #      requested_run_time: ${time.format(sys.now())}
+                    

--- a/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
+++ b/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
@@ -282,14 +282,14 @@ paginateConfigs:
                   in: ${pageResults.transferConfigs}
                   steps:
                     - checkCondition:
-                      switch:
-                        - condition: ${transferConfig.displayName == "RecommenderAPIExport"}
-                          steps:
-                            - export_configId:
-                                assign:
-                                  - transferConfigId: ${transferConfig.name}
-                                # returning as there is no need to continue looping.
-                                next: break
+                        switch:
+                          - condition: ${transferConfig.displayName == "RecommenderAPIExport"}
+                            steps:
+                              - export_configId:
+                                  assign:
+                                    - transferConfigId: ${transferConfig.name}
+                                  # returning as there is no need to continue looping.
+                                  next: break
                     - finalExists:
                         return: ${transferConfigId}
       - checkNextPage:

--- a/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
+++ b/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
@@ -220,19 +220,22 @@ createDataExportIfNeeded:
   steps:
   - init:
       assign:
+        - combinedResults: []
         - transferConfigId: null
   - checkIfTransferConfigExists:
       try:
         steps:
           - getAllConfigs:
-              call: googleapis.bigquerydatatransfer.v1.projects.transferConfigs.list
+              call: paginateConfigs
               args:
                 parent: ${"projects/" + projectId}
-              result: getResults
+                combinedResults: ${combinedResults}
+                pageToken: null
+              result: combinedResults
           - findConfigId:
               for:
                 value: transferConfig
-                in: ${getResults.transferConfigs}
+                in: ${combinedResults}
                 steps:
                   - checkCondition:
                       switch:
@@ -272,6 +275,53 @@ createDataExportIfNeeded:
                 - transferConfigId: ${createResult.name}
   - finalReturn:
       return: ${transferConfigId}
+
+# Recursively called step for handling pagination
+paginateConfigs:
+    params: [parent, combinedResults, pageToken]
+    steps:
+      - listConfigsPage:
+          call: googleapis.bigquerydatatransfer.v1.projects.transferConfigs.list
+          args:
+            parent: ${parent}
+            pageToken: ${pageToken}
+          result: pageResults
+      - checkPageToken:
+          try:
+            steps:
+              - setNextPageToken:
+                  assign:
+                    - nextPageToken: ${pageResults.nextPageToken}
+          except:
+            steps:
+              - setNextPageTokenNull:
+                  assign:
+                    - nextPageToken: null
+      - concatResults:
+          steps:
+            - looping:
+                for:
+                  value: transferConfig
+                  in: ${pageResults.transferConfigs}
+                  steps:
+                    - combine: 
+                        assign:
+                          - combinedResults: ${list.concat(combinedResults, transferConfig)}
+      - checkNextPage:
+          switch:
+            - condition: ${nextPageToken != null}
+              steps:
+                - recursiveCall:
+                    call: paginateConfigs
+                    args:
+                      parent: ${parent}
+                      combinedResults: ${combinedResults}
+                      pageToken: ${nextPageToken}
+                    result: combinedResults
+            - condition: True
+              steps:
+                - finalReturn:
+                    return: ${combinedResults}
 
 
 runExportsInParallel:

--- a/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
+++ b/recommendations-dashboard/terraform/modules/recommendations-dashboard/workflows/recommender-api-export-workflow.yaml
@@ -290,8 +290,6 @@ paginateConfigs:
                                     - transferConfigId: ${transferConfig.name}
                                   # returning as there is no need to continue looping.
                                   next: break
-                    - finalExists:
-                        return: ${transferConfigId}
       - checkNextPage:
           switch:
             - condition: ${nextPageToken != null}


### PR DESCRIPTION
Updated the workflow to account for pagination. In some instances the workflow might create additional transfer configs if the list of transfer configs is long.

This fixes that. 